### PR TITLE
Added support for recent versions of libav

### DIFF
--- a/Blocks/visualizer.cpp
+++ b/Blocks/visualizer.cpp
@@ -38,6 +38,10 @@
 
 #define MFC_MAX_STREAM_SIZE (2*1024*1024)
 
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54,25,0)
+#define CODEC_ID_MPEG4 AV_CODEC_ID_MPEG4
+#define CODEC_ID_MJPEG AV_CODEC_ID_MJPEG
+#endif
 
 int visualizer::OnPaint(XVideoContext *xvc, void *param){
 

--- a/VideoLib/videodecoder.cpp
+++ b/VideoLib/videodecoder.cpp
@@ -24,7 +24,9 @@
  
  #include "videodecoder.h"
 
-
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55,28,1)
+#define avcodec_alloc_frame av_frame_alloc
+#endif
 
 int LibAvInitStatus=0;
 

--- a/VideoLib/videodecoder.h
+++ b/VideoLib/videodecoder.h
@@ -26,6 +26,10 @@ extern "C" {
 }
 #endif
 
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54,25,0)
+#define CodecID AVCodecID
+#endif
+
 class VideoDecoder
 {
 

--- a/visualizer/MakefileAMD64
+++ b/visualizer/MakefileAMD64
@@ -18,7 +18,7 @@ CXXFLAGS      = -m64 -pipe -std=c++11 -Wno-unused-parameter -Wno-sign-compare -O
 INCPATH       = -I../visualizer -I/usr/local/include/lapackpp/ -I../Blocks -I../mtracklib -I../CommLib -I../VideoLib -I../UtilLib -I../NeonLib/ -I.
 LINK          = g++
 LFLAGS        = -m64 -Wl,-O1
-LIBS          = $(SUBLIBS) -L/usr/local/lib -lX11 -lv4l2 -lm -llapack -lavcodec -lGL -lGLU -lglut -lgd -lpthread 
+LIBS          = $(SUBLIBS) -L/usr/local/lib -lX11 -lv4l2 -lm -llapack -lavcodec -lavutil -lGL -lGLU -lglut -lgd -lpthread 
 AR            = ar cqs
 RANLIB        =
 TAR           = tar -cf


### PR DESCRIPTION
I have added macros so that old and recent version of libav can be used.
The linker flag `-lavutil` is required for `av_frame_alloc`
