### PR TITLE
Parameter names didn't match -> 'Detector' vs 'detector'

### DIFF
--- a/ros/src/rebvo_ros/config/rebvo_EuRoC.yaml
+++ b/ros/src/rebvo_ros/config/rebvo_EuRoC.yaml
@@ -51,11 +51,10 @@ rebvo:
 
 
   Detector:
-    Sigma0: 3.56359
+    Sigma0: 1.7818
     KSigma: 1.2599
-    ReferencePoints: 15000
-    MaxPoints: 40000
-    TrackPoints: 12000
+    ReferencePoints: 12000
+    MaxPoints: 16000
     DetectorThresh: 0.01
     DetectorAutoGain: 5e-7
     DetectorMaxThresh: 0.5
@@ -70,7 +69,7 @@ rebvo:
     QCutOffNumBins: 100
     QCutOffQuantile: 0.9
     TrackerIterNum: 5
-    TrackerInitType: 0
+    TrackerInitType: 2
     TrackerInitIterNum: 2
     TrackerMatchThresh: 0.5
     MatchThreshModule: 1

--- a/ros/src/rebvo_ros/src/rebvo_nodelet.cpp
+++ b/ros/src/rebvo_ros/src/rebvo_nodelet.cpp
@@ -303,18 +303,18 @@ void RebvoNodelet::construct() {
 
 
 	// Rebvo Detector parameters
-    private_nh_.param<double>("rebvo/detector/Sigma0", rebvoPars.Sigma0, 3.56359);
-    private_nh_.param<double>("rebvo/detector/KSigma", rebvoPars.KSigma, 1.2599);
-	private_nh_.param<int>("rebvo/detector/ReferencePoints", rebvoPars.ReferencePoints, 12000);
-	private_nh_.param<int>("rebvo/detector/MaxPoints", rebvoPars.MaxPoints, 16000);
-    private_nh_.param<int>("rebvo/detector/TrackPoints", rebvoPars.TrackPoints, rebvoPars.MaxPoints);
-	private_nh_.param<double>("rebvo/detector/DetectorThresh", rebvoPars.DetectorThresh, 0.01);
-	private_nh_.param<double>("rebvo/detector/DetectorAutoGain", rebvoPars.DetectorAutoGain, 5e-7);
-	private_nh_.param<double>("rebvo/detector/DetectorMaxThresh", rebvoPars.DetectorMaxThresh, 0.5);
-	private_nh_.param<double>("rebvo/detector/DetectorMinThresh", rebvoPars.DetectorMinThresh, 0.005);
-	private_nh_.param<int>("rebvo/detector/DetectorPlaneFitSize", rebvoPars.DetectorPlaneFitSize, 2);
-	private_nh_.param<double>("rebvo/detector/DetectorPosNegThresh", rebvoPars.DetectorPosNegThresh, 0.4);
-	private_nh_.param<double>("rebvo/detector/DetectorDoGThresh", rebvoPars.DetectorDoGThresh, 0.095259868922420);
+    private_nh_.param<double>("rebvo/Detector/Sigma0", rebvoPars.Sigma0, 3.56359);
+    private_nh_.param<double>("rebvo/Detector/KSigma", rebvoPars.KSigma, 1.2599);
+	private_nh_.param<int>("rebvo/Detector/ReferencePoints", rebvoPars.ReferencePoints, 12000);
+	private_nh_.param<int>("rebvo/Detector/MaxPoints", rebvoPars.MaxPoints, 16000);
+    private_nh_.param<int>("rebvo/Detector/TrackPoints", rebvoPars.TrackPoints, rebvoPars.MaxPoints);
+	private_nh_.param<double>("rebvo/Detector/DetectorThresh", rebvoPars.DetectorThresh, 0.01);
+	private_nh_.param<double>("rebvo/Detector/DetectorAutoGain", rebvoPars.DetectorAutoGain, 5e-7);
+	private_nh_.param<double>("rebvo/Detector/DetectorMaxThresh", rebvoPars.DetectorMaxThresh, 0.5);
+	private_nh_.param<double>("rebvo/Detector/DetectorMinThresh", rebvoPars.DetectorMinThresh, 0.005);
+	private_nh_.param<int>("rebvo/Detector/DetectorPlaneFitSize", rebvoPars.DetectorPlaneFitSize, 2);
+	private_nh_.param<double>("rebvo/Detector/DetectorPosNegThresh", rebvoPars.DetectorPosNegThresh, 0.4);
+	private_nh_.param<double>("rebvo/Detector/DetectorDoGThresh", rebvoPars.DetectorDoGThresh, 0.095259868922420);
 
 	// Rebvo TrackMaper parameters
 	private_nh_.param<double>("rebvo/TrackMaper/SearchRange", rebvoPars.SearchRange, 40);


### PR DESCRIPTION
Parameter names didn't match -> 'Detector' (configuration file) vs. 'detector' (source code)
